### PR TITLE
feat: add a subset of properties for stackset stack manipulation

### DIFF
--- a/src/stackset-stack.ts
+++ b/src/stackset-stack.ts
@@ -40,8 +40,26 @@ export class StackSetStackSynthesizer extends StackSynthesizer {
  * Properties for a StackSet Deployment. Subset of normal Stack properties.
  */
 interface StackSetStackProps {
+  /**
+   * Include runtime versioning information in this Stack
+   *
+   * @default `analyticsReporting` setting of containing `App`, or value of
+   * 'aws:cdk:version-reporting' context key
+   */
   readonly analyticsReporting?: boolean;
+
+  /**
+   * A description of the stack.
+   *
+   * @default - No description.
+   */
   readonly description?: string;
+
+  /**
+   * Stack tags that will be applied to all the taggable resources and the stack itself.
+   *
+   * @default {}
+   */
   readonly tags?: { [key: string]: string };
 }
 

--- a/src/stackset-stack.ts
+++ b/src/stackset-stack.ts
@@ -75,7 +75,7 @@ export class StackSetStack extends Stack {
   public readonly templateFile: string;
   private _templateUrl?: string;
   private _parentStack: Stack;
-  constructor(scope: Construct, id: string, props: StackSetStackProps) {
+  constructor(scope: Construct, id: string, props: StackSetStackProps = {}) {
     super(scope, id, {
       synthesizer: new StackSetStackSynthesizer(),
       ...props,

--- a/src/stackset-stack.ts
+++ b/src/stackset-stack.ts
@@ -36,6 +36,14 @@ export class StackSetStackSynthesizer extends StackSynthesizer {
   }
 }
 
+/**
+ * Properties for a StackSet Deployment. Subset of normal Stack properties.
+ */
+interface StackSetStackProps {
+  readonly analyticsReporting?: boolean;
+  readonly description?: string;
+  readonly tags?: { [key: string]: string };
+}
 
 /**
  * A StackSet stack, which is similar to a normal CloudFormation stack with
@@ -49,9 +57,10 @@ export class StackSetStack extends Stack {
   public readonly templateFile: string;
   private _templateUrl?: string;
   private _parentStack: Stack;
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, props: StackSetStackProps) {
     super(scope, id, {
       synthesizer: new StackSetStackSynthesizer(),
+      ...props,
     });
 
     this._parentStack = findParentStack(scope);


### PR DESCRIPTION
Addresses #116 

the current implementation of this provides some known properties that are ok to pass along, rather than everything except the `synthesizer` property.