### PR TITLE
fix: ensure the admin role stabilizes for self-managed stacksets

### DIFF
--- a/src/stackset.ts
+++ b/src/stackset.ts
@@ -658,6 +658,10 @@ export class StackSet extends Resource implements IStackSet {
       stackInstancesGroup: Lazy.any({ produce: () => { return this.stackInstances; } }),
     });
 
+    if (this._role) {
+      stackSet.node.addDependency(this._role);
+    }
+
     // the file asset bucket deployment needs to complete before the stackset can deploy
     for (const fileAssetResourceName of fileAssetResourceNames) {
       const fileAssetResource = scope.node.tryFindChild(fileAssetResourceName);

--- a/test/integ.stack-set.ts.snapshot/integ-stackset-test.template.json
+++ b/test/integ.stack-set.ts.snapshot/integ-stackset-test.template.json
@@ -84,7 +84,8 @@
     "TemplateURL": {
      "Fn::Sub": "https://s3.test-region.${AWS::URLSuffix}/cdk-hnb659fds-assets-12345678-test-region/fc39dcfb61ca7db050a8c6cf440dde97c2c051f0965e9094eaad4bf1157e63cf.json"
     }
-   }
+   },
+   "DependsOn": ["AdminRoleDefaultPolicy1C2AB961", "AdminRole38563C57"]
   }
  },
  "Parameters": {


### PR DESCRIPTION
Looks like https://github.com/cdklabs/cdk-stacksets/pull/439 tackles the same problem, however, I think `DependsOn` is sufficient and is typically what is used in `aws-cdk-lib`, e.g. https://github.com/aws/aws-cdk/blob/0546ec24c5fa60cae41c6561d7178de7a403a713/packages/%40aws-cdk/aws-kinesisanalytics-flink-alpha/lib/application.ts#L1030

For anyone looking for a workaround with the current release, you can add the dependency like so:
```typescript
if (selfManagedStackSet.role) {
  selfManagedStackSet.node.addDependency(selfManagedStackSet.role);
}
```

fixes #438, supersedes #439 