### PR TITLE
fix: correctly handle asset staging when bundling is disabled

### DIFF
--- a/src/stackset-stack.ts
+++ b/src/stackset-stack.ts
@@ -62,7 +62,7 @@ export class StackSetStackSynthesizer extends StackSynthesizer {
     }
 
     const outdir = App.of(this.boundStack)?.outdir ?? 'cdk.out';
-    const assetPath = `${outdir}/${asset.fileName}`;
+    const assetPath = path.isAbsolute(asset.fileName) ? asset.fileName : path.join(outdir, asset.fileName);
 
     for (const assetBucket of this.assetBuckets) {
       const index = this.assetBuckets.indexOf(assetBucket);

--- a/test/stack-set.test.ts
+++ b/test/stack-set.test.ts
@@ -16,7 +16,15 @@ class LambdaStackSet extends StackSetStack {
     new lambda.Function(this, 'Lambda', {
       runtime: lambda.Runtime.NODEJS_18_X,
       handler: 'index.handler',
-      code: lambda.Code.fromAsset(path.join(__dirname, 'lambda')),
+      code: lambda.Code.fromAsset(path.join(__dirname, 'lambda'), {
+        // Trigger bundling to ensure asset staging behaviour correctly interacts with bundling
+        bundling: {
+          image: lambda.Runtime.NODEJS_18_X.bundlingImage,
+          command: [
+            'bash', '-c', 'echo "fake" > /asset-output/manifest.json',
+          ],
+        },
+      }),
     });
 
     new lambda.Function(this, 'Lambda2', {
@@ -346,6 +354,34 @@ test('test lambda assets with one asset bucket', () => {
   const app = new App({
     context: {
       [cxapi.ASSET_RESOURCE_METADATA_ENABLED_CONTEXT]: true,
+    },
+  });
+  const stack = new Stack(app);
+  const lambdaStack = new LambdaStackSet(stack, 'LambdaStack', {
+    assetBuckets: [s3.Bucket.fromBucketName(stack, 'AssetBucket', 'integ-assets')],
+    assetBucketPrefix: 'prefix',
+  });
+
+  new StackSet(stack, 'StackSet', {
+    target: StackSetTarget.fromAccounts({
+      regions: ['us-east-1'],
+      accounts: ['11111111111'],
+      parameterOverrides: {
+        Param1: 'Value1',
+      },
+    }),
+    template: StackSetTemplate.fromStackSetStack(lambdaStack),
+    capabilities: [Capability.IAM, Capability.NAMED_IAM],
+  });
+
+  Template.fromStack(stack).resourceCountIs('Custom::CDKBucketDeployment', 1);
+});
+
+test('test lambda assets with bundling disabled', () => {
+  const app = new App({
+    context: {
+      [cxapi.ASSET_RESOURCE_METADATA_ENABLED_CONTEXT]: true,
+      [cxapi.BUNDLING_STACKS]: [],
     },
   });
   const stack = new Stack(app);


### PR DESCRIPTION
Fixes #258 

This issue is caused by the behaviour of `AssetStaging.relativeStagedPath()`, which normally returns a path relative to the stack's outdir, but can return an absolute path when staging or bundling is skipped, or when the asset is staged outside of the outdir.
See the docstring on `relativeStagedPath`:
https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/core/lib/asset-staging.ts#L266-L269
And the 'skip' behaviour in `stageByBundling`
https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/core/lib/asset-staging.ts#L310-L325

A test has been added that can be used to demonstrate the issue and shows that it is now resolved.