### PR TITLE
feat: stackset target property is now optional

### DIFF
--- a/API.md
+++ b/API.md
@@ -1574,7 +1574,6 @@ const stackSetProps: StackSetProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#cdk-stacksets.StackSetProps.property.target">target</a></code> | <code><a href="#cdk-stacksets.StackSetTarget">StackSetTarget</a></code> | Which accounts/OUs and regions to deploy the StackSet to. |
 | <code><a href="#cdk-stacksets.StackSetProps.property.template">template</a></code> | <code><a href="#cdk-stacksets.StackSetTemplate">StackSetTemplate</a></code> | The Stack that will be deployed to the target. |
 | <code><a href="#cdk-stacksets.StackSetProps.property.capabilities">capabilities</a></code> | <code><a href="#cdk-stacksets.Capability">Capability</a>[]</code> | Specify a list of capabilities required by your stackset. |
 | <code><a href="#cdk-stacksets.StackSetProps.property.deploymentType">deploymentType</a></code> | <code><a href="#cdk-stacksets.DeploymentType">DeploymentType</a></code> | The type of deployment for this StackSet. |
@@ -1583,18 +1582,7 @@ const stackSetProps: StackSetProps = { ... }
 | <code><a href="#cdk-stacksets.StackSetProps.property.operationPreferences">operationPreferences</a></code> | <code><a href="#cdk-stacksets.OperationPreferences">OperationPreferences</a></code> | The operation preferences for the StackSet. |
 | <code><a href="#cdk-stacksets.StackSetProps.property.parameters">parameters</a></code> | <code>{[ key: string ]: string}</code> | The input parameters for the stack set template. |
 | <code><a href="#cdk-stacksets.StackSetProps.property.stackSetName">stackSetName</a></code> | <code>string</code> | The name of the stack set. |
-
----
-
-##### `target`<sup>Required</sup> <a name="target" id="cdk-stacksets.StackSetProps.property.target"></a>
-
-```typescript
-public readonly target: StackSetTarget;
-```
-
-- *Type:* <a href="#cdk-stacksets.StackSetTarget">StackSetTarget</a>
-
-Which accounts/OUs and regions to deploy the StackSet to.
+| <code><a href="#cdk-stacksets.StackSetProps.property.target">target</a></code> | <code><a href="#cdk-stacksets.StackSetTarget">StackSetTarget</a></code> | Which accounts/OUs and regions to deploy the StackSet to. |
 
 ---
 
@@ -1717,6 +1705,19 @@ public readonly stackSetName: string;
 - *Default:* CloudFormation generated name
 
 The name of the stack set.
+
+---
+
+##### `target`<sup>Optional</sup> <a name="target" id="cdk-stacksets.StackSetProps.property.target"></a>
+
+```typescript
+public readonly target: StackSetTarget;
+```
+
+- *Type:* <a href="#cdk-stacksets.StackSetTarget">StackSetTarget</a>
+- *Default:* no targets. You can use `addTarget()` after construction to add targets.
+
+Which accounts/OUs and regions to deploy the StackSet to.
 
 ---
 

--- a/src/stackset.ts
+++ b/src/stackset.ts
@@ -425,8 +425,10 @@ class SelfDeploymentType extends DeploymentType {
 export interface StackSetProps {
   /**
    * Which accounts/OUs and regions to deploy the StackSet to
+   *
+   * @default - no targets. You can use `addTarget()` after construction to add targets.
    */
-  readonly target: StackSetTarget;
+  readonly target?: StackSetTarget;
 
   /**
    * The Stack that will be deployed to the target
@@ -690,7 +692,9 @@ export class StackSet extends Resource implements IStackSet {
 
     this.permissionModel = deploymentTypeConfig.permissionsModel;
 
-    this.addTarget(props.target);
+    if (props.target) {
+      this.addTarget(props.target);
+    }
     const stackSet = new cfn.CfnStackSet(this, 'Resource', {
       autoDeployment: undefinedIfNoKeys({
         enabled: deploymentTypeConfig.autoDeployEnabled,

--- a/test/stack-set.test.ts
+++ b/test/stack-set.test.ts
@@ -431,6 +431,54 @@ test('test lambda assets with two asset buckets', () => {
   Template.fromStack(stack).resourceCountIs('Custom::CDKBucketDeployment', 2);
 });
 
+test('stackset without target', () => {
+  const app = new App();
+  const stack = new Stack(app);
+
+  new StackSet(stack, 'StackSet', {
+    template: StackSetTemplate.fromStackSetStack(new StackSetStack(stack, 'Stack')),
+  });
+
+  Template.fromStack(stack).hasResourceProperties('AWS::CloudFormation::StackSet', {
+    ManagedExecution: { Active: true },
+    PermissionModel: 'SELF_MANAGED',
+    TemplateURL: {
+      'Fn::Sub': 'https://s3.${AWS::Region}.${AWS::URLSuffix}/cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a.json',
+    },
+  });
+
+  // No StackInstancesGroup should be present when no target is provided
+  const template = Template.fromStack(stack);
+  const stackSets = template.findResources('AWS::CloudFormation::StackSet');
+  const stackSetResource = Object.values(stackSets)[0];
+  expect(stackSetResource.Properties.StackInstancesGroup).toEqual([]);
+});
+
+test('stackset without target then addTarget', () => {
+  const app = new App();
+  const stack = new Stack(app);
+
+  const stackSet = new StackSet(stack, 'StackSet', {
+    template: StackSetTemplate.fromStackSetStack(new StackSetStack(stack, 'Stack')),
+  });
+
+  stackSet.addTarget(StackSetTarget.fromAccounts({
+    regions: ['us-east-1'],
+    accounts: ['11111111111'],
+  }));
+
+  Template.fromStack(stack).hasResourceProperties('AWS::CloudFormation::StackSet', {
+    ManagedExecution: { Active: true },
+    PermissionModel: 'SELF_MANAGED',
+    StackInstancesGroup: [{
+      Regions: ['us-east-1'],
+      DeploymentTargets: {
+        Accounts: ['11111111111'],
+      },
+    }],
+  });
+});
+
 test('passes operation preferences', () => {
   const app = new App();
   const stack = new Stack(app);


### PR DESCRIPTION
This enables creation of stacksets without targets.
My use case: I want to first create a stackset with no targets in CDK, then use `aws cloudformation import-stacks-to-stack-set` CLI to import existing stacks into the stackset, then update the CDK to add the targets.