### PR TITLE
feat: intersectionAccounts target option

### DIFF
--- a/API.md
+++ b/API.md
@@ -1340,6 +1340,7 @@ const organizationsTargetOptions: OrganizationsTargetOptions = { ... }
 | <code><a href="#cdk-stacksets.OrganizationsTargetOptions.property.organizationalUnits">organizationalUnits</a></code> | <code>string[]</code> | A list of organizational unit ids to deploy to. |
 | <code><a href="#cdk-stacksets.OrganizationsTargetOptions.property.additionalAccounts">additionalAccounts</a></code> | <code>string[]</code> | A list of additional AWS accounts to deploy the StackSet to. |
 | <code><a href="#cdk-stacksets.OrganizationsTargetOptions.property.excludeAccounts">excludeAccounts</a></code> | <code>string[]</code> | A list of AWS accounts to exclude from deploying the StackSet to. |
+| <code><a href="#cdk-stacksets.OrganizationsTargetOptions.property.intersectionAccounts">intersectionAccounts</a></code> | <code>string[]</code> | A list of AWS accounts to intersect with the organizational units. |
 
 ---
 
@@ -1424,6 +1425,22 @@ A list of AWS accounts to exclude from deploying the StackSet to.
 This can
 be useful if there are accounts that exist in an OU that is provided in
 `organizationalUnits`, but you do not want the StackSet to be deployed.
+
+---
+
+##### `intersectionAccounts`<sup>Optional</sup> <a name="intersectionAccounts" id="cdk-stacksets.OrganizationsTargetOptions.property.intersectionAccounts"></a>
+
+```typescript
+public readonly intersectionAccounts: string[];
+```
+
+- *Type:* string[]
+- *Default:* Stacks will be deployed to all accounts in the specified OUs
+
+A list of AWS accounts to intersect with the organizational units.
+
+Only accounts that are BOTH in the specified OUs AND in this list
+will have the StackSet deployed.
 
 ---
 

--- a/src/stackset.ts
+++ b/src/stackset.ts
@@ -116,6 +116,15 @@ export interface OrganizationsTargetOptions extends TargetOptions {
    * specified in the organizationUnits property
    */
   readonly excludeAccounts?: string[];
+
+  /**
+   * A list of AWS accounts to intersect with the organizational units.
+   * Only accounts that are BOTH in the specified OUs AND in this list
+   * will have the StackSet deployed.
+   *
+   * @default - Stacks will be deployed to all accounts in the specified OUs
+   */
+  readonly intersectionAccounts?: string[];
 }
 
 /**
@@ -247,19 +256,25 @@ class OrganizationsTarget extends StackSetTarget {
   }
 
   public _bind(_scope: Construct, _options: TargetBindOptions = {}): StackSetTargetConfig {
-    if (this.options.excludeAccounts && this.options.additionalAccounts) {
-      throw new Error("cannot specify both 'excludeAccounts' and 'additionalAccounts'");
+    const specified = [
+      this.options.additionalAccounts,
+      this.options.excludeAccounts,
+      this.options.intersectionAccounts,
+    ].filter(Boolean).length;
+    if (specified > 1) {
+      throw new Error("specify at most one of 'additionalAccounts', 'excludeAccounts', or 'intersectionAccounts'");
     }
 
     const filterType = this.options.additionalAccounts ? AccountFilterType.UNION
       : this.options.excludeAccounts ? AccountFilterType.DIFFERENCE
-        : AccountFilterType.NONE;
+        : this.options.intersectionAccounts ? AccountFilterType.INTERSECTION
+          : AccountFilterType.NONE;
     return {
       regions: this.options.regions,
       parameterOverrides: this._renderParameters(this.options.parameterOverrides),
       accountFilterType: filterType,
       organizationalUnits: this.options.organizationalUnits,
-      accounts: this.options.additionalAccounts ?? this.options.excludeAccounts,
+      accounts: this.options.additionalAccounts ?? this.options.excludeAccounts ?? this.options.intersectionAccounts,
     };
   }
 }

--- a/test/stack-set.test.ts
+++ b/test/stack-set.test.ts
@@ -325,6 +325,99 @@ test('fromOrganizations default', () => {
 
 });
 
+test('fromOrganizations with intersectionAccounts', () => {
+  const app = new App();
+  const stack = new Stack(app);
+
+  new StackSet(stack, 'StackSet', {
+    target: StackSetTarget.fromOrganizationalUnits({
+      regions: ['us-east-1'],
+      organizationalUnits: ['ou-1111111'],
+      intersectionAccounts: ['222222222222', '333333333333'],
+    }),
+    deploymentType: DeploymentType.serviceManaged({
+      delegatedAdmin: false,
+      autoDeployEnabled: false,
+    }),
+    template: StackSetTemplate.fromStackSetStack(new StackSetStack(stack, 'Stack')),
+  });
+
+  Template.fromStack(stack).hasResourceProperties('AWS::CloudFormation::StackSet', {
+    StackInstancesGroup: [{
+      Regions: ['us-east-1'],
+      DeploymentTargets: {
+        AccountFilterType: 'INTERSECTION',
+        OrganizationalUnitIds: ['ou-1111111'],
+        Accounts: ['222222222222', '333333333333'],
+      },
+    }],
+  });
+});
+
+test('fromOrganizations throws when intersectionAccounts and excludeAccounts are both specified', () => {
+  const app = new App();
+  const stack = new Stack(app);
+
+  expect(() => {
+    new StackSet(stack, 'StackSet', {
+      target: StackSetTarget.fromOrganizationalUnits({
+        regions: ['us-east-1'],
+        organizationalUnits: ['ou-1111111'],
+        intersectionAccounts: ['222222222222'],
+        excludeAccounts: ['333333333333'],
+      }),
+      deploymentType: DeploymentType.serviceManaged({
+        delegatedAdmin: false,
+        autoDeployEnabled: false,
+      }),
+      template: StackSetTemplate.fromStackSetStack(new StackSetStack(stack, 'Stack')),
+    });
+  }).toThrow(/specify at most one of 'additionalAccounts', 'excludeAccounts', or 'intersectionAccounts'/);
+});
+
+test('fromOrganizations throws when intersectionAccounts and additionalAccounts are both specified', () => {
+  const app = new App();
+  const stack = new Stack(app);
+
+  expect(() => {
+    new StackSet(stack, 'StackSet', {
+      target: StackSetTarget.fromOrganizationalUnits({
+        regions: ['us-east-1'],
+        organizationalUnits: ['ou-1111111'],
+        intersectionAccounts: ['222222222222'],
+        additionalAccounts: ['333333333333'],
+      }),
+      deploymentType: DeploymentType.serviceManaged({
+        delegatedAdmin: false,
+        autoDeployEnabled: false,
+      }),
+      template: StackSetTemplate.fromStackSetStack(new StackSetStack(stack, 'Stack')),
+    });
+  }).toThrow(/specify at most one of 'additionalAccounts', 'excludeAccounts', or 'intersectionAccounts'/);
+});
+
+test('fromOrganizations throws when all three account filters are specified', () => {
+  const app = new App();
+  const stack = new Stack(app);
+
+  expect(() => {
+    new StackSet(stack, 'StackSet', {
+      target: StackSetTarget.fromOrganizationalUnits({
+        regions: ['us-east-1'],
+        organizationalUnits: ['ou-1111111'],
+        intersectionAccounts: ['111111111111'],
+        excludeAccounts: ['222222222222'],
+        additionalAccounts: ['333333333333'],
+      }),
+      deploymentType: DeploymentType.serviceManaged({
+        delegatedAdmin: false,
+        autoDeployEnabled: false,
+      }),
+      template: StackSetTemplate.fromStackSetStack(new StackSetStack(stack, 'Stack')),
+    });
+  }).toThrow(/specify at most one of 'additionalAccounts', 'excludeAccounts', or 'intersectionAccounts'/);
+});
+
 test('has IAM capabilities', () => {
   const app = new App();
   const stack = new Stack(app);


### PR DESCRIPTION
Fixes #286
This enables management of stacksets targeting the intersection of account ID and OU