### PR TITLE
fix: stackset template asset keys diverge from the objects the asset bucket deployment uploads

### DIFF
--- a/src/stackset-stack.ts
+++ b/src/stackset-stack.ts
@@ -8,6 +8,7 @@ import {
   FileAssetLocation,
   DockerImageAssetLocation,
   DockerImageAssetSource,
+  FileSystem,
   ISynthesisSession,
   Names,
   Lazy,
@@ -120,9 +121,13 @@ export class StackSetStackSynthesizer extends StackSynthesizer {
 
     const bucketName = Fn.join('-', [this.assetBucketPrefix, this.boundStack.region]);
 
-    const assetFileBaseName = path.basename(asset.fileName);
-    const s3Filename = assetFileBaseName.split('.')[1] + '.zip';
-    const objectKey = `${s3Filename}`;
+    // The BucketDeployment above re-stages the asset through `Source.asset()` and,
+    // with `extract: false`, uploads it under the re-staged asset's content
+    // fingerprint. Derive the template's object key the same way so the two can
+    // never diverge: the hash embedded in the staged file name is not always the
+    // content fingerprint (for example, aws-cdk-lib >= 2.258.0 stages its
+    // custom-resource handler assets with an explicit `assetHash`).
+    const objectKey = `${FileSystem.fingerprint(assetPath)}.zip`;
     const s3ObjectUrl = `s3://${bucketName}/${objectKey}`;
     const httpUrl = `https://s3.${bucketName}/${objectKey}`;
 

--- a/test/stack-set.test.ts
+++ b/test/stack-set.test.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import path from 'path';
 import {
   App, Stack, aws_lambda as lambda, aws_s3 as s3,
@@ -522,6 +523,54 @@ test('test lambda assets with two asset buckets', () => {
   });
 
   Template.fromStack(stack).resourceCountIs('Custom::CDKBucketDeployment', 2);
+});
+
+test('lambda asset keys in the stackset template match the bucket deployment uploads', () => {
+  const app = new App();
+  const stack = new Stack(app);
+  const stackSetStack = new StackSetStack(stack, 'CustomHashStack', {
+    assetBuckets: [s3.Bucket.fromBucketName(stack, 'AssetBucket', 'integ-assets')],
+    assetBucketPrefix: 'prefix',
+  });
+
+  // Mirrors aws-cdk-lib >= 2.258.0 custom-resource handler assets, which are
+  // staged with an explicit assetHash: the hash embedded in the staged asset
+  // name no longer equals the content fingerprint the bucket deployment
+  // uploads under.
+  new lambda.Function(stackSetStack, 'CustomHashLambda', {
+    runtime: lambda.Runtime.NODEJS_18_X,
+    handler: 'index.handler',
+    code: lambda.Code.fromAsset(path.join(__dirname, 'lambda'), { assetHash: 'custom-hash' }),
+  });
+
+  new StackSet(stack, 'StackSet', {
+    target: StackSetTarget.fromAccounts({
+      regions: ['us-east-1'],
+      accounts: ['11111111111'],
+    }),
+    template: StackSetTemplate.fromStackSetStack(stackSetStack),
+    capabilities: [Capability.IAM, Capability.NAMED_IAM],
+  });
+
+  const uploadedKeys = Object.values(Template.fromStack(stack).findResources('Custom::CDKBucketDeployment'))
+    .flatMap(resource => resource.Properties?.SourceObjectKeys as string[]);
+
+  const assembly = app.synth();
+  const templateFile = fs.readdirSync(assembly.directory).find(file => file.endsWith('.stackset.template.json'));
+  expect(templateFile).toBeDefined();
+  const stackSetResources: Record<string, { Type: string; Properties?: { Code?: { S3Key?: string } } }> = JSON.parse(
+    fs.readFileSync(path.join(assembly.directory, templateFile!), 'utf8'),
+  ).Resources;
+
+  const lambdaAssetKeys = Object.values(stackSetResources)
+    .filter(resource => resource.Type === 'AWS::Lambda::Function')
+    .map(resource => resource.Properties?.Code?.S3Key)
+    .filter((key): key is string => key !== undefined);
+
+  expect(lambdaAssetKeys.length).toBeGreaterThan(0);
+  for (const key of lambdaAssetKeys) {
+    expect(uploadedKeys).toContain(key);
+  }
 });
 
 test('stackset without target', () => {


### PR DESCRIPTION
Fixes #895

## Problem

Deploying a `StackSet` whose `StackSetStack` contains an `AwsCustomResource` (or any construct backed by an aws-cdk-lib custom-resource handler) fails on every stack instance with:

```
ResourceType:AWS::Lambda::Function, ResourceStatusReason:Resource handler returned message:
"Error occurred while GetObject. S3 Error Code: NoSuchKey. ..."
```

`StackSetStackSynthesizer.addFileAsset()` derives the template's S3 object key from the hash embedded in the staged asset file name:

```ts
const assetFileBaseName = path.basename(asset.fileName);
const s3Filename = assetFileBaseName.split('.')[1] + '.zip';
```

But the object that actually lands in the asset bucket is uploaded by the `BucketDeployment` created in the same method: `Source.asset(assetPath)` re-stages the staged asset and computes a fresh **content fingerprint**, and with `extract: false` the destination object key is that fingerprint — not the hash in the staged file name.

These two keys are only identical when the original asset's hash *is* the plain content fingerprint. That implicit assumption broke with **aws-cdk-lib 2.258.0**: [aws/aws-cdk#37634](https://github.com/aws/aws-cdk/pull/37634) ("custom-resource-handlers: deterministic asset hashes for generated lambdas") stages all generated custom-resource handler assets with an explicit `assetHash`, e.g.:

```js
code: lambda.Code.fromAsset(path.join(__dirname, "aws-custom-resource-handler"), {
  assetHash: "048c51b339711116c3b9feefa3c6aff37c49dba2a4d0f1f531fa8337d9602d82"
}),
```

I verified the regression window release by release: the generated handlers in aws-cdk-lib 2.254.0–2.257.0 contain no `assetHash`; 2.258.0 is the first version that does. Concrete values from a real deployment on 2.258.1:

- staged folder: `cdk.out/asset.8b1c21ef...` (derived from the custom `assetHash`)
- template `Code.S3Key`: `8b1c21ef....zip` → **never uploaded** → `NoSuchKey`
- key actually uploaded by the `BucketDeployment`: `0528c009....zip` (= `FileSystem.fingerprint()` of the staged directory)

## Fix

Derive the template's object key the same way `Source.asset()` does, so the two can never diverge:

```ts
const objectKey = `${FileSystem.fingerprint(assetPath)}.zip`;
```

For assets whose hash already is the content fingerprint (plain directory assets, pre-zipped bundled assets such as `NodejsFunction` output), this produces the exact same key as before — no template churn, no re-uploads. Only custom-hash assets, which were broken, change key.

## Testing

- New regression test `lambda asset keys in the stackset template match the bucket deployment uploads` synthesizes a `StackSetStack` containing a Lambda asset with an explicit `assetHash` and asserts every `Code.S3Key` in the stackset template appears in the parent stack's `Custom::CDKBucketDeployment` `SourceObjectKeys`. It fails against the previous implementation and passes with this change.
- Full suite: 20/20 tests, eslint, and the `integ.stack-set` snapshot pass unchanged.
- Verified end to end in a real AWS Organization: a landing-zone deployment that consistently failed with `NoSuchKey` on aws-cdk-lib 2.258.1 deploys successfully with this fix applied.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license.
